### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - ${{ github.event.repository.default_branch }}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2.2'
+          bundler: '2.4.22'
+          bundler-cache: true
+
+      - name: Install dependencies
+        run: bundle install --jobs 4 --retry 3
+
+      - name: Publish to GitHub Pages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ALLOW_DIRTY: "true"
+        run: bundle exec rake publish

--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ Clear/delete build folder before this step
 ```sh
 rm -rf build/ && bundle exec rake publish ALLOW_DIRTY=true # Build and publish to Github Pages
 ```
+## Automated Deployment
+
+The site is automatically deployed using GitHub Actions whenever changes are pushed to the repository's primary branch. The workflow defined in `.github/workflows/deploy.yml` installs Ruby 3.2.2, runs `bundle install`, and executes `bundle exec rake publish` with `ALLOW_DIRTY=true`. The build directory is pushed to `gh-pages` using the built-in `GITHUB_TOKEN` secret, which has write permissions to the repo. If you prefer to use a personal token, ensure it has `contents: write` permission and add it as a secret.
+
 
 
 ## Configuration


### PR DESCRIPTION
## Summary
- add deploy workflow that uses Ruby 3.2.2
- document workflow in README
- give workflow permissions to push to repo

## Testing
- `bundle exec rake build` *(fails: Could not find builder-3.3.0, middleman-4.5.1, ...)*

------
https://chatgpt.com/codex/tasks/task_e_684c7c7088f4832291b19891844ffb5b